### PR TITLE
Safe fix for xcode 16 beta 6

### DIFF
--- a/Sources/CImGui/include/cimgui.h
+++ b/Sources/CImGui/include/cimgui.h
@@ -5,6 +5,7 @@
 #define CIMGUI_INCLUDED
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 #if defined _WIN32 || defined __CYGWIN__
     #ifdef CIMGUI_NO_EXPORT
         #define API


### PR DESCRIPTION
This package is not building on Xcode 16 beta 6.

To fix, I had to add <string.h> to have strlen available in the swift extensions; as an alternative, I rewrote strlen myself, but I was concerned that the Swift version might be too slow compared to the native C one, and not knowing the context in which it’s used, I preferred to apply a conservative fix, even though it’s definitely more of a temporary workaround.

Once Xcode 16 is RC we can assess whatever this fix will still be necessary.